### PR TITLE
Fix comment in observer

### DIFF
--- a/lib/observer.go
+++ b/lib/observer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
-//Observe directory dir. If there is new file send its name by chanel
+// Observe directory dir. If a new file appears, send its name by channel
 func newFileCheck(dir string, logger *log.Logger) (newFileAlert <-chan string, err error) {
 	logging.Info(logger, fmt.Sprintf("Observing %s directory", dir))
 	watcher, err := fsnotify.NewWatcher()


### PR DESCRIPTION
## Summary
- fix comment text for directory observer

## Testing
- `GO111MODULE=off go test ./...` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_68400dcbd00c833098d34a3e713bf050