### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ In `config.hcl` you can configure integration with Consul. You can provide value
 
 - `enable` - Enables Consul registration
 - `name` - Name of the service
-- `address` - Consul adrress
+- `address` - Consul address
 - `deregister_on_service_stop = true` - Enables deregistration from Consul when service is stopped
 
 Metrics


### PR DESCRIPTION
## Summary
- fix a typo in README line 94

## Testing
- `go build ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68400da884bc8330aaafa4ed8e74ad87